### PR TITLE
Do not close file descriptor, fixes error on rosetta 'ps: stdout: Bad…

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -70,7 +70,7 @@ EOF
 
     echo "Check status"
     sleep 5
-    if ! ps -p $! >&-; then
+    if ! ps -p $! >/dev/null ; then
       echo "Process exited"
       cat "$log_path"
       exit 1


### PR DESCRIPTION
Fixing bug on Rosetta: `ps: stdout: Bad file descriptor`.
Do not close stdout, instead redirect it to /dev/null.

Running on rosetta: https://app.bitrise.io/build/af07f5e3-5362-48a1-b74d-610119b826ea

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
